### PR TITLE
Fix permissions 406 response error when exporting

### DIFF
--- a/services/exporter.js
+++ b/services/exporter.js
@@ -25,7 +25,7 @@ async function getAll(uid, ctx) {
   );
 
   // Filter content by permissions
-  const query = permissionsManager.queryFrom("", PERMISSIONS.read);
+  const query = permissionsManager.queryFrom({}, PERMISSIONS.read);
   const items = await strapi.entityService.find(
     { params: query },
     { model: uid }


### PR DESCRIPTION
Fixes this error in the latest Strapi release (3.6.2):

TypeError: Cannot read property 'concat' of undefined at Object.queryFrom (/strapi/node_modules/strapi-admin/services/permission/permissions-manager/index.js:52:42)