### PR TITLE
fix import fails if value is null #38

### DIFF
--- a/services/utils/contentChecker.js
+++ b/services/utils/contentChecker.js
@@ -3,6 +3,7 @@ const { urlIsMedia } = require("./formatsValidator");
 const { importMediaFromUrl } = require("../importer/importMediaFiles");
 
 function getId(value) {
+  if( value === null ) return null;
   if (typeof value === "number") return value;
   if (typeof value === "object" && value.id) return value.id;
   return null;


### PR DESCRIPTION
During Import (After Analyze completed), some of the value needs to be imported is null. since null is "object" type on the line 8 of contentChecker.js file. This is true and the next command `value.id` cause TypeError `TypeError: Cannot read property 'id' of null`

And the whole import stops.
Added another if to handle if the value is null. 